### PR TITLE
Updated to support multi-slot transclusion

### DIFF
--- a/angularjs/angular.d.ts
+++ b/angularjs/angular.d.ts
@@ -1713,7 +1713,7 @@ declare module angular {
         /**
          * Whether transclusion is enabled. Enabled by default.
          */
-        transclude?: boolean;
+        transclude?: any;
         /**
          * Whether the new scope is isolated. Isolated by default.
          */


### PR DESCRIPTION
Transclude property is no longer a boolean but a string dictionary object.